### PR TITLE
Add test to reproduce UnicodeDecodeError bug at py27

### DIFF
--- a/tests/a_script.py
+++ b/tests/a_script.py
@@ -10,6 +10,9 @@ def main(args):
     if args == ['stdin']:
         print(sys.stdin.read().upper())
         return
+    if args == ['ff-stdout']:
+        print('\xFF')
+        return
     for arg in args:
         print('Writing %s' % arg)
         open(arg, 'w').write('test')

--- a/tests/test_testscript.py
+++ b/tests/test_testscript.py
@@ -69,3 +69,9 @@ os.symlink(os.path.join('does', 'not', 'exist.txt'), "does-not-exist.txt")
     assert res.files_created['does-not-exist.txt'].invalid
     # Just make sure there's no error:
     str(res)
+
+
+def test_ff_stdout(tmpdir):
+    env = TestFileEnvironment(str(tmpdir), start_clear=False)
+    res = env.run(sys.executable, script, 'ff-stdout')
+    assert res.stdout == '\xFF\n'


### PR DESCRIPTION
Hi!

At py27 scripttest try to decode nonvalid utf8 stdout of script to utf8 and failed with UnicodeDecodeError.
I add test to reproduce this bug.

I run this test at py27 and py33 with

```
tox -e py27,py33
```

At py27 failed
At py33 succeed
