### PR TITLE
Fix #4. Document debug option.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,9 @@ Then you run scripts with ``env.run(script, arg1, arg2, ...)``::
 
 There's several keyword arguments you can use with ``env.run()``:
 
+``debug``: (default False)
+    Don't pipe output. Note that this will cause the returned object's
+    ``stdout`` and ``stderr`` attributes to be emtpy strings.
 ``expect_error``: (default False)
     Don't raise an exception in case of errors
 ``expect_stderr``: (default ``expect_error``)

--- a/scripttest.py
+++ b/scripttest.py
@@ -196,6 +196,9 @@ class TestFileEnvironment(object):
 
         Keywords allowed are:
 
+        ``debug``: (default False)
+            Don't pipe output. Note that this will cause the returned object's
+            ``stdout`` and ``stderr`` attributes to be emtpy strings.
         ``expect_error``: (default False)
             Don't raise an exception in case of errors
         ``expect_stderr``: (default ``expect_error``)
@@ -255,7 +258,9 @@ class TestFileEnvironment(object):
                                     env=clean_environ(self.environ))
 
         if debug:
-            stdout, stderr = proc.communicate()
+            proc.communicate()
+            stdout = ''
+            stderr = ''
         else:
             stdout, stderr = proc.communicate(stdin)
         stdout = string(stdout)


### PR DESCRIPTION
An alternative to PR #5.

Issue #4 should only apply to debug mode, so no reason to check on every `string` call.

Also, document the debug flag and note that `stdout` and `stderr` will be empty.
