### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,4 +16,4 @@ With it you can easily run the command (in a subprocess) and see the
 output (stdout, stderr) and any file modifications.
 
 * The `source repository <https://github.com/pypa/scripttest>`_.
-* The `documentation <https://scripttest.readthedocs.org/>`_.
+* The `documentation <https://scripttest.readthedocs.io/>`_.

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
     keywords='test unittest doctest command line scripts',
     author='Ian Bicking',
     author_email='ianb@colorstudy.com',
-    url='http://scripttest.readthedocs.org/en/stable/',
+    url='https://scripttest.readthedocs.io/en/stable/',
     license='MIT',
     py_modules=['scripttest'],
     tests_require=['pytest'],


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.