### PR TITLE
Use self.assert_no_temp for expect_temp calls

### DIFF
--- a/scripttest.py
+++ b/scripttest.py
@@ -230,7 +230,7 @@ class TestFileEnvironment(object):
         if not expect_stderr:
             result.assert_no_stderr(quiet)
         if not expect_temp:
-            result.assert_no_temp(quiet)
+            self.assert_no_temp(quiet)
         return result
 
     def _find_files(self):


### PR DESCRIPTION
@pfmoore Ping for another review.

Turns out, there's _two_ `assert_no_temp` functions, and we call the other one. :(
